### PR TITLE
Facebook and Twitter image size tags

### DIFF
--- a/src/Meta/Post.php
+++ b/src/Meta/Post.php
@@ -29,12 +29,34 @@ class Post {
 			[ 'property' => 'og:url',			'content' => get_permalink( $post->ID ) ],
 			[ 'property' => 'og:site_name',		'content' => get_bloginfo( 'title' ) ],
 			[ 'property' => 'og:updated_time',	'content' => get_post_modified_time( 'c', true, $post ) ],
-			[ 'property' => 'og:image',			'content' => self::get_post_og_image( $post ) ],
 			[ 'name' => 'twitter:card',			'content' => 'summary' ],
 			[ 'name' => 'twitter:title',		'content' => self::get_post_twitter_title( $post ) ],
 			[ 'name' => 'twitter:description',	'content' => self::get_post_twitter_description( $post ) ],
-			[ 'name' => 'twitter:image',		'content' => self::get_post_twitter_image( $post ) ],
 		];
+
+		$og_image = self::get_post_og_image( $post );
+		$twitter_image = self::get_post_twitter_image( $post );
+
+		if ( ! empty( $og_image ) ) {
+			$og_image_size = getimagesize( $og_image );
+
+			$tags = array_merge( $tags, [
+				[ 'property' => 'og:image',			'content' => $og_image ],
+				[ 'property' => 'og:image:width',	'content' => $og_image_size[0] ],
+				[ 'property' => 'og:image:height',	'content' => $og_image_size[1] ],
+			] );
+		}
+
+		if ( ! empty( $twitter_image ) ) {
+			$twitter_image_size = getimagesize( $twitter_image );
+
+			$tags = array_merge( $tags, [
+				[ 'name' => 'twitter:image',		'content' => $twitter_image ],
+				[ 'name' => 'twitter:image:width',	'content' => $twitter_image_size[0] ],
+				[ 'name' => 'twitter:image:height',	'content' => $twitter_image_size[1] ],
+			] );
+		}
+
 		$tags = array_merge( $tags, Site::webmaster_tools() );
 
 		return [


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature,
  docs update, ...)

Feature
- **What is the current behavior?** (You can also link to an open issue
  here)

Facebook and Twitter image size tags are not being displayed, which generates that the posts images are not being shown in the first share of the URLs on the social networks.
- **What is the new behavior (if this is a feature change)?**

Facebook and Twitter image size tags added.
- **Does this PR introduce a breaking change?** (What changes might
  users need to make in their application due to this PR?)

No
- **Other information**:
